### PR TITLE
Handles user timeline request limit

### DIFF
--- a/TwitterMySQL/TwitterMySQL.py
+++ b/TwitterMySQL/TwitterMySQL.py
@@ -277,7 +277,7 @@ class TwitterMySQL:
 
 		self._connection = MySQLdb.connect(**kwargs)
 		self.cur = self._connection.cursor()
-
+        
 	def _wait(self, t, verbose = True):
 		"""Wait function, offers a nice countdown"""
 		for i in xrange(t):
@@ -298,7 +298,7 @@ class TwitterMySQL:
 		try:
 			ret = self.cur.execute(query)
 		except Exception as e:
-			if "MySQL server has gone away" in str(e):
+			if ("MySQL server has gone away" in str(e)) or isinstance(e, MySQLdb.InterfaceError):
 				self._connect()
 			nbAttempts += 1
 			if not verbose: print "SQL:\t%s" % query[:200]
@@ -321,7 +321,7 @@ class TwitterMySQL:
 			for i in xrange(len(values)):
 				ret += self.cur.execute(query, values[i])
 		except Exception as e:
-			if "MySQL server has gone away" in str(e):
+			if ("MySQL server has gone away" in str(e)) or isinstance(e, MySQLdb.InterfaceError): 
 				self._connect()
 				nbAttempts += 1
 				if not verbose: print "SQL:\t%s" % query[:200]

--- a/twInterface.py
+++ b/twInterface.py
@@ -101,6 +101,8 @@ if __name__ == '__main__':
                         help='List of MySQL columns to save, instead of full list given in TwitterMySQL')
     parser.add_argument('--save_json', dest='savejson', default='',
                         help='Location (directory path) to save raw tweets as json files.')
+    parser.add_argument('--log_file', dest='logfile', default='./logs', 
+                        help='Location (file path) to save logs saying the users that were scraped.')
     args = parser.parse_args()
     
     # where are we writing everything? no database needed for profile pictures or social networks
@@ -251,6 +253,7 @@ if __name__ == '__main__':
             search_params['trim_user'] = 'true'
         if args.noretweets:
             search_params['include_rts'] = 'false'
+        f = open(args.logfile, 'w')
         tt = 0
         for user in open(args.userlist):
             tt += 1
@@ -261,7 +264,9 @@ if __name__ == '__main__':
             else:
                 user_params = {"screen_name": search_params["screen_name"]}
 
-            print("########## User {tt}: {u}".format(tt=tt, u=user))
+            string = "########## User {tt}: {u}".format(tt=tt, u=user)
+            print(string)
+            f.write(string + '\n')
             try:
                 user_object = twtSQL._apiRequestNoRetry(twitterMethod="users/show", params=user_params).next()
             except:


### PR DESCRIPTION
- As of June 2019, Twitter has limited the user timeline request [(link to forum post)](https://twittercommunity.com/t/mentions-and-user-timeline-request-limit-goes-into-effect-today/127044) to single 100,000 requests in a 24-hour period to `/statuses/mentions_timeline` and `/statuses/user_timeline` per app. However, it returns the traditional `429` error with `x-rate-limit-*` of 15-minute. Current PR monitors the number of requests per app and rotates to other apps until the request counts are replenished.
- In addition to this fix, the current PR also includes a tweak to dump the successfully grabbed user IDs to a file so that we can pause and resume the grabber.